### PR TITLE
refactor: simplify data & prop access

### DIFF
--- a/components/animated_background.vue
+++ b/components/animated_background.vue
@@ -30,28 +30,28 @@
             this.$refs.background.querySelectorAll('#Pre-cloud-tracks path').forEach((elm, index) => {
                 const id = `PreCloudTracks${index}`;
                 elm.setAttribute('id', id);
-                this.$data.pre[id] = 0;
+                this.pre[id] = 0;
             });
             this.$refs.background.querySelectorAll('#Post-cloud-tracks path').forEach((elm, index) => {
                 const id = `PostCloudTracks${index}`;
                 elm.setAttribute('id', id);
-                this.$data.post[id] = 0;
+                this.post[id] = 0;
             });
 
             // Do the origin feeds
-            Object.keys(this.$data.pre).forEach((id) => {
+            Object.keys(this.pre).forEach((id) => {
                 const path = this.$refs.background.querySelector(`#${id}`);
-                this.create(path, 0, this.$data.preSpeed,
+                this.create(path, 0, this.preSpeed,
                             () => Math.random() * 3 - 1, d => d * 2 * Math.random());
             });
 
             // Do the edge feeds
-            Object.keys(this.$data.post).forEach((id) => {
+            Object.keys(this.post).forEach((id) => {
                 const path = this.$refs.background.querySelector(`#${id}`);
                 const pathIndex = Number(id.match(/^.+(\d+)/)[1]);
                 const dots = 6 - pathIndex;
                 for (let i = 0; i < dots; i++) {
-                    this.create(path, i, this.$data.postSpeed, () => -i / dots, d => pathIndex < 2 ? 0 : d);
+                    this.create(path, i, this.postSpeed, () => -i / dots, d => pathIndex < 2 ? 0 : d);
                 }
             });
         },

--- a/components/json-ld/library.vue
+++ b/components/json-ld/library.vue
@@ -17,7 +17,7 @@
         },
         computed: {
             json () {
-                return JSON.stringify(Library(this.base, this.$props.library, this.$props.libraryName));
+                return JSON.stringify(Library(this.base, this.library, this.libraryName));
             },
             base () {
                 const origin = process.env.SITE_HOST ||

--- a/components/json-ld/tutorial.vue
+++ b/components/json-ld/tutorial.vue
@@ -20,9 +20,9 @@
             json () {
                 return JSON.stringify(Tutorial(
                     this.base,
-                    this.$props.tutorial,
-                    this.$props.tutorialName,
-                    this.$props.library,
+                    this.tutorial,
+                    this.tutorialName,
+                    this.library,
                 ));
             },
             base () {

--- a/components/json-ld/tutorials.vue
+++ b/components/json-ld/tutorials.vue
@@ -17,11 +17,11 @@
         },
         computed: {
             json () {
-                return JSON.stringify(Tutorials(this.base, this.$props.library, this.$props.tutorials, this.keywords));
+                return JSON.stringify(Tutorials(this.base, this.library, this.tutorials, this.keywords));
             },
             keywords () {
                 const tags = [];
-                for (const tutorial of this.$props.tutorials) {
+                for (const tutorial of this.tutorials) {
                     if (tutorial.keywords) {
                         tags.push(...tutorial.keywords);
                     }

--- a/components/json_example.vue
+++ b/components/json_example.vue
@@ -37,10 +37,10 @@
         },
         methods: {
             raw () {
-                this.$data.showRaw = true;
+                this.showRaw = true;
             },
             formatted () {
-                this.$data.showRaw = false;
+                this.showRaw = false;
             },
         },
     };

--- a/components/library/library_card.vue
+++ b/components/library/library_card.vue
@@ -43,10 +43,10 @@
         computed: {
             asset () {
                 return getAsset(
-                    this.$props.library.name,
-                    this.$props.library.version,
-                    this.$props.library.filename,
-                    this.$props.library.sri,
+                    this.library.name,
+                    this.library.version,
+                    this.library.filename,
+                    this.library.sri,
                 );
             },
         },

--- a/components/library/library_hero.vue
+++ b/components/library/library_hero.vue
@@ -88,20 +88,20 @@
             version: {
                 immediate: true,
                 async handler () {
-                    this.$data.vulns = await getVulns(this.$props.library, this.$props.version).catch(() => {});
+                    this.vulns = await getVulns(this.library, this.version).catch(() => {});
                 },
             },
         },
         async created () {
-            this.$data.vulns = await getVulns(this.$props.library, this.$props.version).catch(() => {});
+            this.vulns = await getVulns(this.library, this.version).catch(() => {});
         },
         methods: {
             formatUnits,
             utm,
             repo () {
-                if (this.$props.library.algolia && this.$props.library.algolia.github &&
-                    this.$props.library.algolia.github.user && this.$props.library.algolia.github.repo) {
-                    return `${this.$props.library.algolia.github.user}/${this.$props.library.algolia.github.repo}`;
+                if (this.library.algolia && this.library.algolia.github &&
+                    this.library.algolia.github.user && this.library.algolia.github.repo) {
+                    return `${this.library.algolia.github.user}/${this.library.algolia.github.repo}`;
                 }
             },
         },

--- a/components/search/inline_search.vue
+++ b/components/search/inline_search.vue
@@ -86,7 +86,7 @@
         },
         computed: {
             active () {
-                return this.$data.showHits && (this.$data.hasFocus || this.$data.query);
+                return this.showHits && (this.hasFocus || this.query);
             },
         },
         watch: {
@@ -96,52 +96,52 @@
         },
         created () {
             getStats().then((data) => {
-                this.$data.placeholder = `Search from ${data.libraries.toLocaleString()} libraries on cdnjs...`;
+                this.placeholder = `Search from ${data.libraries.toLocaleString()} libraries on cdnjs...`;
             });
         },
         updated () {
-            if (this.$props.autofocus) {
+            if (this.autofocus) {
                 // Autofocus the search box once it gets rendered
                 // I hate how incredibly hacky this feels, but it works
-                if (!this.$data.autofocusDone &&
+                if (!this.autofocusDone &&
                     this.$refs.search &&
                     this.$refs.search.$children &&
                     this.$refs.search.$children[0] &&
                     this.$refs.search.$children[0].$refs &&
                     this.$refs.search.$children[0].$refs.input) {
                     // Focus the input
-                    this.$data.autofocusDone = true;
+                    this.autofocusDone = true;
                     this.$refs.search.$children[0].$refs.input.focus();
 
                     // Disable focus events for a tick
-                    this.$nextTick(() => { this.$data.listenForFocus = true; });
+                    this.$nextTick(() => { this.listenForFocus = true; });
                 }
             }
         },
         methods: {
             focused () {
                 // Don't act as focused if autofocus
-                if (this.$props.autofocus && !this.$data.listenForFocus) {
+                if (this.autofocus && !this.listenForFocus) {
                     return;
                 }
 
                 // Register a listener for results
-                if (!this.$data.listenerRegistered) {
+                if (!this.listenerRegistered) {
                     this.$refs.instantSearch.instantSearchInstance.on('render', () => {
                         this.$nextTick(() => {
                             // Set a margin so it doesn't overflow the page (if enabled)
-                            if (this.$props.margin) {
+                            if (this.margin) {
                                 const results = this.$refs.results.$el;
                                 results.parentElement.style.marginBottom = this.active ? `${results.offsetHeight + 4}px` : null;
                             }
                         });
                     });
-                    this.$data.listenerRegistered = true;
+                    this.listenerRegistered = true;
                 }
 
                 // Ensure we are showing hits now they're using the input
-                this.$data.showHits = true;
-                this.$data.hasFocus = true;
+                this.showHits = true;
+                this.hasFocus = true;
             },
             blurred () {
                 // If no query, this will hide the default results
@@ -149,7 +149,7 @@
                 setTimeout(() => {
                     this.$nextTick(() => {
                         this.$nextTick(() => {
-                            this.$data.hasFocus = false;
+                            this.hasFocus = false;
                         });
                     });
                 }, 200);
@@ -162,12 +162,12 @@
                 this.$router.push({
                     name: 'libraries',
                     query: {
-                        q: this.$data.query,
+                        q: this.query,
                     },
                 });
             },
             getQuery () {
-                this.$data.query = (this.$refs.search ? this.$refs.search.$children[0].$refs.input.value : undefined) || undefined;
+                this.query = (this.$refs.search ? this.$refs.search.$children[0].$refs.input.value : undefined) || undefined;
             },
             doSearch (requests) {
                 // Only run the actual search if active

--- a/components/search/primary_search.vue
+++ b/components/search/primary_search.vue
@@ -92,19 +92,19 @@
         },
         created () {
             getStats().then((data) => {
-                this.$data.placeholder = `Search from ${data.libraries.toLocaleString()} libraries on cdnjs...`;
+                this.placeholder = `Search from ${data.libraries.toLocaleString()} libraries on cdnjs...`;
             });
         },
         updated () {
             // Autofocus the search box once it gets rendered
             // I hate how incredibly hacky this feels, but it works
-            if (!this.$data.autofocusDone &&
+            if (!this.autofocusDone &&
                 this.$refs.search &&
                 this.$refs.search.$children &&
                 this.$refs.search.$children[0] &&
                 this.$refs.search.$children[0].$refs &&
                 this.$refs.search.$children[0].$refs.input) {
-                this.$data.autofocusDone = true;
+                this.autofocusDone = true;
                 this.$refs.search.$children[0].$refs.input.focus();
             }
         },

--- a/components/status_indicator.vue
+++ b/components/status_indicator.vue
@@ -30,12 +30,12 @@
         },
         methods: {
             async updateStatus () {
-                const data = await status(this.$props.pageId);
-                this.$data.status = data.status;
+                const data = await status(this.pageId);
+                this.status = data.status;
                 this.$refs.dot.className = `status-indicator status-indicator-${data.status.indicator}`;
             },
             tooltipShow (evt) {
-                evt.target.setAttribute('data-tlite', this.$data.status.description);
+                evt.target.setAttribute('data-tlite', this.status.description);
                 tlite.show(evt.target);
             },
             tooltipHide (evt) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -45,7 +45,7 @@
         },
         watch: {
             classes () {
-                this.$data.showBg = this.$data.classes.includes('landing');
+                this.showBg = this.classes.includes('landing');
             },
         },
         created () {
@@ -59,22 +59,22 @@
         },
         mounted () {
             this.$refs.nuxt.$on('beforeLeave', () => {
-                this.$data.showSearch = false;
-                this.$data.classes = this.$data.classes.filter(c => c !== 'ready');
+                this.showSearch = false;
+                this.classes = this.classes.filter(c => c !== 'ready');
             });
             this.$refs.nuxt.$on('afterLeave', () => {
-                this.$data.classes = [];
+                this.classes = [];
             });
             this.$refs.nuxt.$on('beforeEnter', () => {
                 this.setClasses();
                 this.checkInlineSearch();
             });
             this.$refs.nuxt.$on('afterEnter', () => {
-                this.$data.classes.push('ready');
+                this.classes.push('ready');
             });
             this.setClasses();
             this.checkInlineSearch();
-            this.$nextTick(() => this.$data.classes.push('ready'));
+            this.$nextTick(() => this.classes.push('ready'));
         },
         methods: {
             checkTrailingSlash () {
@@ -97,24 +97,24 @@
             checkInlineSearch () {
                 // Hide search on landing
                 if (this.$nuxt.context.route.name === 'index') {
-                    this.$data.showSearch = false;
+                    this.showSearch = false;
                     return;
                 }
 
                 // Hide search on libraries
                 if (this.$nuxt.context.route.name === 'libraries') {
-                    this.$data.showSearch = false;
+                    this.showSearch = false;
                     return;
                 }
 
                 // Otherwise, show it
-                this.$data.showSearch = true;
+                this.showSearch = true;
             },
             setClasses () {
                 // Handle the error page which isn't a route
                 if (this.$nuxt.context._errored) {
-                    this.$data.classes = ['error', 'landing'];
-                    this.$nextTick(() => this.$data.classes.push('ready'));
+                    this.classes = ['error', 'landing'];
+                    this.$nextTick(() => this.classes.push('ready'));
                     return;
                 }
 
@@ -134,7 +134,7 @@
                 }
 
                 // Store it!
-                this.$data.classes = newClasses;
+                this.classes = newClasses;
             },
         },
     };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,10 +61,10 @@
         },
         methods: {
             active () {
-                this.$data.searchActive = true;
+                this.searchActive = true;
             },
             inactive () {
-                this.$data.searchActive = false;
+                this.searchActive = false;
             },
         },
         head () {

--- a/pages/libraries/_library/index.vue
+++ b/pages/libraries/_library/index.vue
@@ -186,44 +186,44 @@
         computed: {
             versions () {
                 try {
-                    return semverSort.desc(this.$data.library.versions);
+                    return semverSort.desc(this.library.versions);
                 } catch (_) {
-                    return this.$data.library.versions;
+                    return this.library.versions;
                 }
             },
         },
         watch: {
             async version () {
                 // Update the asset list
-                this.$data.assetsMessage = `Loading assets for ${this.$data.libraryName}/${this.$data.version}...`;
-                await getAssetsData(this.$data);
+                this.assetsMessage = `Loading assets for ${this.libraryName}/${this.version}...`;
+                await getAssetsData(this);
 
                 // Update the URL without navigating
                 const newRoute = this.$router.resolve({
                     name: 'libraries-library-version',
-                    params: { ...this.$route.params, version: this.$data.version },
+                    params: { ...this.$route.params, version: this.version },
                     query: this.$route.query,
                 });
                 window.history.pushState({}, '', newRoute.href);
 
                 // Update the crumbs
-                this.$data.params = newRoute.route.params;
-                this.$data.crumbs = await breadcrumbs(newRoute.route, this.$router, this.$data);
+                this.params = newRoute.route.params;
+                this.crumbs = await breadcrumbs(newRoute.route, this.$router, this);
             },
         },
         async mounted () {
-            if (!this.$data.assets || !this.$data.assets.length) {
-                await getAssetsData(this.$data);
+            if (!this.assets || !this.assets.length) {
+                await getAssetsData(this);
             }
         },
         methods: {
             formatUnits,
             hideAsset (asset) {
-                if (asset.hidden && !this.$data.showHidden) {
+                if (asset.hidden && !this.showHidden) {
                     return true;
                 }
-                if (this.$data.category !== 'All') {
-                    return asset.category !== this.$data.category;
+                if (this.category !== 'All') {
+                    return asset.category !== this.category;
                 }
                 return false;
             },

--- a/pages/libraries/_library/tutorials/_tutorial.vue
+++ b/pages/libraries/_library/tutorials/_tutorial.vue
@@ -133,7 +133,7 @@
                         return `<pre class="${langClass}"><code class="${langClass}">${highlighted}</code></pre>`;
                     },
                 });
-                return md.render(this.$data.tutorial.content);
+                return md.render(this.tutorial.content);
             },
         },
         mounted () {


### PR DESCRIPTION
## Type of Change

- **Something else:** Refactoring data access

## What issue does this relate to?

None

### What should this PR do?

Vue does not strictly require a separation between props and data. Both are available directly as keys of `this`. E.g. having prop `numbers` and a data key called `letters`. Both can be accessed via `this.numbers` and `this.letters`.

I've replaced all `this.$props` and `this.$data` calls with a simplified `this`.
If this separation is intended however, feel free to close this PR.

Also, I haven't tested the full website so I'd suggest double-checking nothing breaks if that PR is being considered 😋