### PR TITLE
chore: add rel attributes to footer links

### DIFF
--- a/components/footer.vue
+++ b/components/footer.vue
@@ -13,11 +13,13 @@
                     </span>
                     <a :href="utm('https://twitter.com/cdnjs', 'footer')"
                        aria-label="cdnjs on Twitter"
+                       rel="noopener"
                     >
                         <Twitter class="icon" aria-hidden="true"></Twitter>
                     </a>
                     <a :href="utm('https://github.com/cdnjs', 'footer')"
                        aria-label="cdnjs on GitHub"
+                       rel="noopener"
                     >
                         <GitHub class="icon" aria-hidden="true"></GitHub>
                     </a>
@@ -34,7 +36,7 @@
                     </nuxt-link>
                 </dd>
                 <dd>
-                    <a :href="utm('https://swag.cdnjs.com', 'footer')">
+                    <a :href="utm('https://swag.cdnjs.com', 'footer')" rel="noopener">
                         Swag Store
                     </a>
                 </dd>
@@ -42,22 +44,22 @@
                 <dd class="break"></dd>
 
                 <dd>
-                    <a :href="utm('https://cdnjs.discourse.group', 'footer')">
+                    <a :href="utm('https://cdnjs.discourse.group', 'footer')" rel="noopener">
                         Community Discourse
                     </a>
                 </dd>
                 <dd>
-                    <a :href="utm('https://opencollective.com/cdnjs', 'footer')">
+                    <a :href="utm('https://opencollective.com/cdnjs', 'footer')" rel="noopener">
                         OpenCollective
                     </a>
                 </dd>
                 <dd>
-                    <a :href="utm('https://www.patreon.com/cdnjs', 'footer')">
+                    <a :href="utm('https://www.patreon.com/cdnjs', 'footer')" rel="noopener">
                         Patreon
                     </a>
                 </dd>
                 <dd>
-                    <a :href="utm('https://www.cloudflare.com/network/', 'footer')">
+                    <a :href="utm('https://www.cloudflare.com/network/', 'footer')" rel="noopener">
                         CDN Network Map
                     </a>
                 </dd>
@@ -78,17 +80,17 @@
 
                 <dt>Status</dt>
                 <dd>
-                    <a :href="utm('https://status.cdnjs.com', 'footer')">
+                    <a :href="utm('https://status.cdnjs.com', 'footer')" rel="noopener">
                         Status Page
                     </a>
                 </dd>
                 <dd>
-                    <a :href="utm('https://twitter.com/cdnjsStatus', 'footer')">
+                    <a :href="utm('https://twitter.com/cdnjsStatus', 'footer')" rel="noopener">
                         cdnjsStatus on Twitter
                     </a>
                 </dd>
                 <dd>
-                    <a :href="utm('http://stats.pingdom.com/4jg86a2wqei0', 'footer')">
+                    <a :href="utm('http://stats.pingdom.com/4jg86a2wqei0', 'footer')" rel="noopener">
                         CDN Uptime
                     </a>
                 </dd>
@@ -97,7 +99,7 @@
             <dl>
                 <dt>Sponsors</dt>
                 <dd v-for="sponsor in sponsors">
-                    <a :href="utm(sponsor.site, 'footer')">
+                    <a :href="utm(sponsor.site, 'footer')" rel="sponsored noopener">
                         {{ sponsor.name }}
                     </a>
                 </dd>


### PR DESCRIPTION
## Type of Change

- **Something else:** Best Practices

## What issue does this relate to?

None

### What should this PR do?
This PR adds rel attributes to the link in the footer.
All external links (`<a>` tags) receive a `rel="noopener"`. Sponsored links are marked as `sponsored` in addition to adhere to the [webmaster guidelines](https://support.google.com/webmasters/answer/96569?).