### PR TITLE
Ensure URLs in sitemap are URL encoded

### DIFF
--- a/util/build/routes.js
+++ b/util/build/routes.js
@@ -13,27 +13,27 @@ export default async () => {
 
             const tutorials = libJson.tutorials.map((tut) => {
                 return {
-                    url: `/libraries/${lib.name}/tutorials/${tut.id}`,
+                    url: `/libraries/${encodeURIComponent(lib.name)}/tutorials/${encodeURIComponent(tut.id)}`,
                     priority: 0.5,
                 };
             });
 
             const versions = libJson.versions.map((version) => {
                 return {
-                    url: `/libraries/${lib.name}/${version}`,
+                    url: `/libraries/${encodeURIComponent(lib.name)}/${encodeURIComponent(version)}`,
                     priority: 0.5,
                 };
             });
 
             return [
                 {
-                    url: `/libraries/${lib.name}`,
+                    url: `/libraries/${encodeURIComponent(lib.name)}`,
                     priority: 0.6,
                 },
                 ...tutorials,
                 ...versions,
                 {
-                    url: `/libraries/${lib.name}/tutorials`,
+                    url: `/libraries/${encodeURIComponent(lib.name)}/tutorials`,
                     priority: 0.4,
                 },
             ];


### PR DESCRIPTION
## Type of Change

- **Utilities:** Routes/sitemap generation

## What issue does this relate to?

N/A

### What should this PR do?

URLs in the generated sitemaps were not encoded correctly, which was causing issues for libraries with special characters in their names or versions. This updates the route generate logic to ensure everything is correctly URL encoded.

### What are the acceptance criteria?

Sitemap contains correctly encoded URLs.