### PR TITLE
Fix code block overflow on mobile

### DIFF
--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -20,6 +20,15 @@ pre {
     border-radius: $radius;
     box-shadow: $shadow;
   }
+
+  > code {
+    overflow: auto;
+
+    &[class*="language-"] {
+      overflow: initial;
+      padding: 0;
+    }
+  }
 }
 
 .code-toolbar {


### PR DESCRIPTION
## Type of Change

- **Styling:** Code blocks

## What issue does this relate to?

N/A

### What should this PR do?

Fixes overflow handling on code blocks on mobile:

| Branch | Master |
|--|--|
| ![image](https://user-images.githubusercontent.com/12371363/94917034-ad641900-04a7-11eb-9702-f13ffd55d0d5.png) | ![image](https://user-images.githubusercontent.com/12371363/94917048-b654ea80-04a7-11eb-8480-53d287865078.png) |

### What are the acceptance criteria?

Code blocks don't overflow on any device.
