### PR TITLE
Fix Snyk library lookup

### DIFF
--- a/util/get_vulns.js
+++ b/util/get_vulns.js
@@ -2,15 +2,9 @@ import fetch from 'node-fetch';
 import { snykApi, snykKey } from '../data/config';
 
 export default async (library, version) => {
-    let libname = library.name;
-    if (library.autoupdate && library.autoupdate.source === 'npm') {
-        libname = library.autoupdate.target;
-    }
-    if (libname.endsWith('.js')) {
-        libname = libname.slice(0, -3);
-    }
+    const lib = library.autoupdate && library.autoupdate.source === 'npm' ? library.autoupdate.target : library.name;
 
-    const res = await fetch(`${snykApi}/test/npm/lib/${encodeURIComponent(libname)}/${encodeURIComponent(version)}`,
+    const res = await fetch(`${snykApi}/test/npm/lib/${encodeURIComponent(lib)}/${encodeURIComponent(version)}`,
         { headers: { Authorization: snykKey } });
     return res.json();
 };


### PR DESCRIPTION
## Type of Change

- **Utilities:** Snyk library lookup

## What issue does this relate to?

Fixes #74

### What should this PR do?

Cleans up the Snyk integration and removes the `.js` trimming which was causing issues for legitimate libraries.

### What are the acceptance criteria?

Snyk integration works.