### PR TITLE
Allow setting API base URL from env var

### DIFF
--- a/data/config.js
+++ b/data/config.js
@@ -1,3 +1,3 @@
-export const baseApi = 'https://api.cdnjs.com';
+export const baseApi = process.env.API_BASE || 'https://api.cdnjs.com';
 export const snykApi = 'https://snyk-widget.herokuapp.com';
 export const snykKey = 'VRHr?YP_Gb7d9LFh$ugktZHUe+gGBp#LGG3*bDLt';

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -215,5 +215,11 @@ export default async () => {
                 release: version,
             },
         },
+        /*
+        ** Ensure that our env is exposed within Nuxt
+        */
+        env: {
+            API_BASE: process.env.API_BASE,
+        },
     };
 };


### PR DESCRIPTION
## Type of Change

- **Utilities:** API config data

## What issue does this relate to?

cc https://github.com/cdnjs/api-server/pull/45

### What should this PR do?

Allows setting the base URL for the API via an environment variable -- this is so that our staging website can use our staging API for testing.

### What are the acceptance criteria?

When the env var is set, the website correctly uses the set API. This has been tested on staging.