### PR TITLE
Add deprecation notice for assets prop of library endpoint

### DIFF
--- a/assets/scss/components/_json_example.scss
+++ b/assets/scss/components/_json_example.scss
@@ -51,6 +51,7 @@
       box-shadow: $shadow;
       font-size: 14px;
       margin: ($whitespace * .5) 0 0;
+      padding: $whitespace;
       white-space: normal;
     }
   }

--- a/components/api/library.vue
+++ b/components/api/library.vue
@@ -23,8 +23,9 @@
                 <ExclamationTriangle class="icon" />
                 <div>
                     <p>
-                        Access to older versions in the <code>assets</code> property of libraries is deprecated.
-                        This array will now only contain a single entry for the latest version.
+                        Accessing <code>assets</code> for all versions of a library using this endpoint is deprecated.
+                        The <code>assets</code> property now only contains a single entry for the latest version.
+                        To access the assets of any version, use the <code>/libraries/:library/:version</code> endpoint.
                     </p>
                     <p>
                         See
@@ -320,7 +321,7 @@
                         ],
                         desc: [
                             'An array containing all the versions of the library available on cdnjs.',
-                            '<small><i>These may, or may not, be valid semver.</i></small>',
+                            '<small><i>These may not be valid semver.</i></small>',
                         ],
                     },
                     {
@@ -329,7 +330,7 @@
                             'array<object>',
                         ],
                         desc: [
-                            'An array containing an object for the latest version of the library on cdnjs, or empty if the library has no known versions.',
+                            'An array containing an object for the latest version of the library on cdnjs. The array is empty if the library has no known versions.',
                             '<small><i>Older versions of the library are no longer included in this array. See deprecation notice.</i></small>',
                         ],
                     },
@@ -340,7 +341,7 @@
                         ],
                         desc: [
                             'The version identifier for this version of the library on cdnjs.',
-                            '<small><i>This may, or may not, be valid semver.</i></small>',
+                            '<small><i>This may not be valid semver.</i></small>',
                         ],
                     },
                     {

--- a/components/api/library.vue
+++ b/components/api/library.vue
@@ -19,6 +19,21 @@
                     </p>
                 </div>
             </div>
+            <div class="callout">
+                <ExclamationTriangle class="icon" />
+                <div>
+                    <p>
+                        Access to older versions in the <code>assets</code> property of libraries is deprecated.
+                        This array will now only contain a single entry for the latest version.
+                    </p>
+                    <p>
+                        See
+                        <a href="https://github.com/cdnjs/cdnjs/issues/14140" target="_blank">
+                            cdnjs/cdnjs issue #14140</a>
+                        for more information.
+                    </p>
+                </div>
+            </div>
 
             <p>
                 The <code>/libraries/:library</code> endpoint allows for data on a specific library to be
@@ -81,7 +96,7 @@
                     <code class="key">https://api.cdnjs.com/libraries/vue?fields=name,author,description,filename,sri,version,repository,autoupdate</code>
                 </a>
             </h4>
-            <JSONExample>{"name":"vue","author":"Evan You &lt;yyx990803@gmail.com&gt;","description":"Simple, Fast & Composable MVVM for building interactive interfaces","filename":"vue.min.js","sri":"sha256-ngFW3UnAN0Tnm76mDuu7uUtYEcG3G5H1+zioJw3t+68=","version":"2.6.11","repository":{"type":"git","url":"https://github.com/vuejs/vue.git"},"autoupdate":{"source":"npm","target":"vue"}}</JSONExample>
+            <JSONExample>{"name":"vue","author":"Evan You &lt;yyx990803@gmail.com&gt;","description":"Simple, Fast & Composable MVVM for building interactive interfaces","filename":"vue.min.js","sri":null,"version":"3.2.37","repository":{"type":"git","url":"https://github.com/vuejs/vue.git"},"autoupdate":{"source":"npm","target":"vue","fileMap":[{"basePath":"dist","files":["**/*.+(js|map)"]}]}}</JSONExample>
 
             <h4>
                 <a href="https://api.cdnjs.com/libraries/react?fields=name,description">
@@ -95,12 +110,7 @@
                     <code class="key">https://api.cdnjs.com/libraries/jquery?fields=assets,versions</code>
                 </a>
             </h4>
-            <JSONExample>{"assets":[{"version":"3.5.1","files":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"rawFiles":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"sri":{"jquery.js":"sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=","jquery.min.js":"sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=","jquery.slim.js":"sha256-DrT5NfxfbHvMHux31Lkhxg42LY6of8TaYyK50jnxRnM=","jquery.slim.min.js":"sha256-4+XzXVhsDmqanXGHaHvgh1gMQKX40OUvDEBTu8JcmNs="}},{"version":"3.5.0","files":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"rawFiles":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"sri":{"jquery.js":"sha256-r/AaFHrszJtwpe+tHyNi/XCfMxYpbsRg2Uqn0x3s2zc=","jquery.min.js":"sha256-xNzN2a4ltkB44Mc/Jz3pT4iU1cmeR0FkXs4pru/JxaQ=","jquery.slim.js":"sha256-sCexhaKpAfuqulKjtSY7V9H7QT0TCN90H+Y5NlmqOUE=","jquery.slim.min.js":"sha256-MlusDLJIP1GRgLrOflUQtshyP0TwT/RHXsI1wWGnQhs="}}, "..."],"versions":["3.5.1","3.5.0","3.4.1","3.4.0","3.3.1","3.3.0","3.2.1","3.2.0","3.1.1","3.1.0","3.0.0","3.0.0-rc1","3.0.0-beta1","3.0.0-alpha1","2.2.4","2.2.3","2.2.2","2.2.1","2.2.0","2.1.4","2.1.3","2.1.2","2.1.1","2.1.1-rc2","2.1.1-rc1","2.1.1-beta1","2.1.0","2.1.0-rc1","2.1.0-beta3","2.1.0-beta2","2.0.3","2.0.2","2.0.1","2.0.0","1.12.4","1.12.3","1.12.2","1.12.1","1.12.0","1.11.3","1.11.2","1.11.1","1.11.1-rc2","1.11.1-rc1","1.11.1-beta1","1.11.0","1.11.0-rc1","1.11.0-beta3","1.10.2","1.10.1","1.10.0","1.9.1","1.9.0","1.8.3","1.8.2","1.8.1","1.8.0","1.7.2","1.7.1","1.6.4","1.6.3","1.6.2","1.6.1","1.5.1","1.4.4","1.4.3","1.4.2","1.4.1","1.4.0","1.3.2","1.3.1","1.3.0","1.2.6","1.2.3","1.7"]}</JSONExample>
-            <p>
-                <small>
-                    <i>Example response has been trimmed to remove items in the assets array.</i>
-                </small>
-            </p>
+            <JSONExample>{"assets":[{"version":"3.6.0","files":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"rawFiles":["jquery.js","jquery.min.js","jquery.min.map","jquery.slim.js","jquery.slim.min.js","jquery.slim.min.map"],"sri":{"jquery.js":"sha512-n/4gHW3atM3QqRcbCn6ewmpxcLAHGaDjpEBu4xZd47N0W2oQ+6q7oc3PXstrJYXcbNU1OHdQ1T7pAP+gi5Yu8g==","jquery.min.js":"sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==","jquery.slim.js":"sha512-HNbo1d4BaJjXh+/e6q4enTyezg5wiXvY3p/9Vzb20NIvkJghZxhzaXeffbdJuuZSxFhJP87ORPadwmU9aN3wSA==","jquery.slim.min.js":"sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A=="}}],"versions":["1.10.0","1.10.1","1.10.2","1.11.0","1.11.0-beta3","1.11.0-rc1","1.11.1","1.11.1-beta1","1.11.1-rc1","1.11.1-rc2","1.11.2","1.11.3","1.12.0","1.12.1","1.12.2","1.12.3","1.12.4","1.2.3","1.2.6","1.3.0","1.3.1","1.3.2","1.4.0","1.4.1","1.4.2","1.4.3","1.4.4","1.5.1","1.6.1","1.6.2","1.6.3","1.6.4","1.7","1.7.1","1.7.2","1.8.0","1.8.1","1.8.2","1.8.3","1.9.0","1.9.1","2.0.0","2.0.1","2.0.2","2.0.3","2.1.0","2.1.0-beta2","2.1.0-beta3","2.1.0-rc1","2.1.1","2.1.1-beta1","2.1.1-rc1","2.1.1-rc2","2.1.2","2.1.3","2.1.4","2.2.0","2.2.1","2.2.2","2.2.3","2.2.4","3.0.0","3.0.0-alpha1","3.0.0-beta1","3.0.0-rc1","3.1.0","3.1.1","3.2.0","3.2.1","3.3.0","3.3.1","3.4.0","3.4.1","3.5.0","3.5.1","3.6.0"]}</JSONExample>
         </div>
     </div>
 </template>
@@ -304,12 +314,23 @@
                         ],
                     },
                     {
+                        prop: 'versions',
+                        type: [
+                            'array<string>',
+                        ],
+                        desc: [
+                            'An array containing all the versions of the library available on cdnjs.',
+                            '<small><i>These may, or may not, be valid semver.</i></small>',
+                        ],
+                    },
+                    {
                         prop: 'assets',
                         type: [
                             'array<object>',
                         ],
                         desc: [
-                            'An array containing an object for each version of the library that cdnjs has available.',
+                            'An array containing an object for the latest version of the library on cdnjs, or empty if the library has no known versions.',
+                            '<small><i>Older versions of the library are no longer included in this array. See deprecation notice.</i></small>',
                         ],
                     },
                     {
@@ -350,15 +371,6 @@
                         ],
                         desc: [
                             'This object will contain a key for each file that cdnjs could calculate an SRI hash for, with the value being the SRI hash.',
-                        ],
-                    },
-                    {
-                        prop: 'versions',
-                        type: [
-                            'array<string>',
-                        ],
-                        desc: [
-                            'An array containing all the versions from <code>assets</code> without the files.',
                         ],
                     },
                     {


### PR DESCRIPTION
## Type of Change

- **Routes/Pages:** API

## What issue does this relate to?

cc https://github.com/cdnjs/cdnjs/issues/14140

### What should this PR do?

Adds a deprecation notice to the library endpoint, indicating that the assets prop will no longer contain all versions. Updates the docs for the assets and versions props to reflect the same, and also updates the examples.

### What are the acceptance criteria?

The library API endpoint is marked with a deprecation notice for the assets property.