### PR TITLE
library_hero.vue: "vulnerabilities" -> "known vulnerabilities"

### DIFF
--- a/components/library/library_hero.vue
+++ b/components/library/library_hero.vue
@@ -27,7 +27,7 @@
             <p v-if="vulns">
                 <a :href="vulns.url">
                     <ShieldAlt class="icon" aria-label="Snyk"></ShieldAlt>
-                    {{ vulns.vulns }} vulnerabilities
+                    {{ vulns.vulns }} known vulnerabilities
                 </a>
             </p>
         </div>


### PR DESCRIPTION
## Type of Change

- **Routes/Pages:**

The "_ vulnerabilities" display on /libraries pages now shows "_ known vulnerabilities" instead. 

This is just a minor nitpick, but to a naïve or rookie developer, "0 vulnerabilities" may appear misleading, especially on smaller packages that haven't had as much audit attention.

### What are the acceptance criteria?
Verify that this change is adequate:

Before:
![image](https://github.com/cdnjs/static-website/assets/1794735/ed4a250a-0f82-4be2-a84b-c24bbd76e042)

After;
![image](https://github.com/cdnjs/static-website/assets/1794735/39125e30-b230-4786-b8ae-d53cfd347d09)
