### PR TITLE
Downgrade instantsearch.js from 4.108.0 to 4.89.0

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -23,3 +23,13 @@ jobs:
 
     - name: Run Tests
       run: npm test
+
+    - name: Build Site
+      run: SITE_HOST=http://localhost:3000/ npm run build
+
+    - name: Check Site
+      run: |
+        trap 'kill $(jobs -p)' EXIT
+        SITE_HOST=http://localhost:3000/ npm run start &
+        sleep 5
+        curl -fsSI http://localhost:3000/

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "imagemin-optipng": "^8.0.0",
         "imagemin-svgo": "^10.0.1",
         "instantsearch.css": "^7.4.5",
+        "instantsearch.js": "^4.89.0",
         "morgan": "^1.11.0",
         "node-fetch": "^2.6.7",
         "nuxt": "^2.17.3",
@@ -2004,13 +2005,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2027,12 +2024,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
@@ -5400,19 +5391,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -6278,9 +6256,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.2.tgz",
-      "integrity": "sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.27.1.tgz",
+      "integrity": "sha512-XXGr02Cz285vLbqM6vPfb39xqV1ptpFr1xn9mqaW+nUvYTvFTdKgYTC/Cg1VzgRTQqNkq9+LlUVv8cfCeOoKig==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -13627,12 +13605,14 @@
       }
     },
     "node_modules/instantsearch-ui-components": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.33.2.tgz",
-      "integrity": "sha512-q8WdUd2BmAEg6iXs8h3nc2FDZvwdVmLYpyp/psDK0ELP7rQiQKOCZjnH1rQZn/mVNM6CxNfcGVDc0i6mKb1K/g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.19.0.tgz",
+      "integrity": "sha512-YU+CVYUwXsUs1yInGVUD+Ox0ttIXUKzZjo6sxhaLAZxO7tJleH7Y222bi+UqDIdmXLjbRy4frE/AImokxMj9Sw==",
       "dependencies": {
-        "@swc/helpers": "0.5.18",
-        "markdown-to-jsx": "^7.7.15"
+        "@babel/runtime": "^7.27.6",
+        "markdown-to-jsx": "^7.7.15",
+        "zod": "^3.25.76 || ^4",
+        "zod-to-json-schema": "3.24.6"
       }
     },
     "node_modules/instantsearch.css": {
@@ -13641,24 +13621,25 @@
       "integrity": "sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ=="
     },
     "node_modules/instantsearch.js": {
-      "version": "4.108.0",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.108.0.tgz",
-      "integrity": "sha512-KGFRvujVi55kFqu+LDSoeeHfpKP/k8IvEec9Q2oLLh9/PghMPkO9hKPk1pa02h/85cZJSv5l4Wa4p4HkFfIZ7A==",
+      "version": "4.89.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.89.0.tgz",
+      "integrity": "sha512-NtrILi3HGWTS6o+N9ymhazB71kG7I0dRo6CVsbRZGPP5SEjBoz4H+KkmEvHFDwK6el6Vqo//wkzlypPCaHb2Vg==",
       "dependencies": {
         "@algolia/events": "^4.0.1",
-        "@swc/helpers": "0.5.18",
         "@types/dom-speech-recognition": "^0.0.1",
         "@types/google.maps": "^3.55.12",
         "@types/hogan.js": "^3.0.0",
         "@types/qs": "^6.5.3",
-        "algoliasearch-helper": "3.29.2",
+        "algoliasearch-helper": "3.27.1",
         "hogan.js": "^3.0.2",
         "htm": "^3.0.0",
-        "instantsearch-ui-components": "0.33.2",
+        "instantsearch-ui-components": "0.19.0",
         "preact": "^10.10.0",
         "qs": "^6.5.1",
         "react": ">= 0.14.0",
-        "search-insights": "^2.17.2"
+        "search-insights": "^2.17.2",
+        "zod": "^3.25.76 || ^4",
+        "zod-to-json-schema": "3.24.6"
       },
       "peerDependencies": {
         "algoliasearch": ">= 3.1 < 6"
@@ -26402,6 +26383,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
     }
   },
   "dependencies": {
@@ -27754,19 +27751,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "requires": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.14.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        }
-      }
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
     },
     "@babel/runtime-corejs3": {
       "version": "7.19.4",
@@ -29913,21 +29900,6 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
-    "@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "requires": {
-        "tslib": "^2.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-        }
-      }
-    },
     "@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -30643,9 +30615,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.2.tgz",
-      "integrity": "sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.27.1.tgz",
+      "integrity": "sha512-XXGr02Cz285vLbqM6vPfb39xqV1ptpFr1xn9mqaW+nUvYTvFTdKgYTC/Cg1VzgRTQqNkq9+LlUVv8cfCeOoKig==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -36143,12 +36115,14 @@
       }
     },
     "instantsearch-ui-components": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.33.2.tgz",
-      "integrity": "sha512-q8WdUd2BmAEg6iXs8h3nc2FDZvwdVmLYpyp/psDK0ELP7rQiQKOCZjnH1rQZn/mVNM6CxNfcGVDc0i6mKb1K/g==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/instantsearch-ui-components/-/instantsearch-ui-components-0.19.0.tgz",
+      "integrity": "sha512-YU+CVYUwXsUs1yInGVUD+Ox0ttIXUKzZjo6sxhaLAZxO7tJleH7Y222bi+UqDIdmXLjbRy4frE/AImokxMj9Sw==",
       "requires": {
-        "@swc/helpers": "0.5.18",
-        "markdown-to-jsx": "^7.7.15"
+        "@babel/runtime": "^7.27.6",
+        "markdown-to-jsx": "^7.7.15",
+        "zod": "^3.25.76 || ^4",
+        "zod-to-json-schema": "3.24.6"
       }
     },
     "instantsearch.css": {
@@ -36157,24 +36131,25 @@
       "integrity": "sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ=="
     },
     "instantsearch.js": {
-      "version": "4.108.0",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.108.0.tgz",
-      "integrity": "sha512-KGFRvujVi55kFqu+LDSoeeHfpKP/k8IvEec9Q2oLLh9/PghMPkO9hKPk1pa02h/85cZJSv5l4Wa4p4HkFfIZ7A==",
+      "version": "4.89.0",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.89.0.tgz",
+      "integrity": "sha512-NtrILi3HGWTS6o+N9ymhazB71kG7I0dRo6CVsbRZGPP5SEjBoz4H+KkmEvHFDwK6el6Vqo//wkzlypPCaHb2Vg==",
       "requires": {
         "@algolia/events": "^4.0.1",
-        "@swc/helpers": "0.5.18",
         "@types/dom-speech-recognition": "^0.0.1",
         "@types/google.maps": "^3.55.12",
         "@types/hogan.js": "^3.0.0",
         "@types/qs": "^6.5.3",
-        "algoliasearch-helper": "3.29.2",
+        "algoliasearch-helper": "3.27.1",
         "hogan.js": "^3.0.2",
         "htm": "^3.0.0",
-        "instantsearch-ui-components": "0.33.2",
+        "instantsearch-ui-components": "0.19.0",
         "preact": "^10.10.0",
         "qs": "^6.5.1",
         "react": ">= 0.14.0",
-        "search-insights": "^2.17.2"
+        "search-insights": "^2.17.2",
+        "zod": "^3.25.76 || ^4",
+        "zod-to-json-schema": "3.24.6"
       }
     },
     "internal-slot": {
@@ -45429,6 +45404,17 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    },
+    "zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "imagemin-optipng": "^8.0.0",
     "imagemin-svgo": "^10.0.1",
     "instantsearch.css": "^7.4.5",
+    "instantsearch.js": "^4.89.0",
     "morgan": "^1.11.0",
     "node-fetch": "^2.6.7",
     "nuxt": "^2.17.3",


### PR DESCRIPTION
## Type of Change

- **Something else:** Dependencies + CI

## What issue does this relate to?

N/A

### What should this PR do?

Downgrades `instantsearch.js` from 4.108.0 to 4.89.0 (updated in #222), which is the last version before `@swc/helpers` was introduced, which causes the site to fail to respond to requests with a `require() of ES Module` error coming from `vue-server-renderer` trying to require `@swc/helpers/esm/_sliced_to_array.js`.

This is likely due to the site still using Node.js 16, as locally I could get past this error by using Node.js 20, but doing that update should be done separately (#150).

Also, introduces a new CI check to ensure that the site homepage can successfully respond to requests.

### What are the acceptance criteria?

Site works.